### PR TITLE
Fix Python version in workflow and Dockerfile

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-﻿name: CI/CD
+name: CI/CD
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
       # 2) Встановлюємо Python
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
 
       # 3) Інсталяція залежностей
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
       - name: Install deps
         run: |
           python -m pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 COPY requirements.txt .


### PR DESCRIPTION
## Summary
- update CI workflow to Python 3.11
- remove BOM in CI/CD workflow and use Python 3.11
- switch Dockerfile to python:3.11-slim

## Testing
- `black --check .`
- `flake8 .`
- `mypy --ignore-missing-imports .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684897e4de9483228dd2be882ea6b131