### PR TITLE
Add test for services page filtering

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,12 +1,18 @@
-﻿import pytest
+import pytest
 from django.urls import reverse
 from core.models import Service
 
 
 @pytest.mark.django_db
 def test_services_page(client):
-    Service.objects.create(title="SEO Audit", slug="seo-audit", is_active=True)
+    Service.objects.create(
+        title="Active Service", slug="active-service", is_active=True
+    )
+    Service.objects.create(
+        title="Inactive Service", slug="inactive-service", is_active=False
+    )
     url = reverse("services")
     resp = client.get(url)
     assert resp.status_code == 200
-    assert b"SEO Audit" in resp.content
+    assert b"Active Service" in resp.content
+    assert b"Inactive Service" not in resp.content


### PR DESCRIPTION
## Summary
- ensure only active services display on services page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68489a024c188322a785b394e64157a0