### PR TITLE
Fix quick-start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a minimal Django project prepared for the **“standard
 
 ```bash
 git clone <your_repo_url>
-cd company_site_skeleton
+cd Company_Site
 python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- fix README instructions to match repo name

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68489a00ad448322854162e84d4247b2