### PR TITLE
Update to Python 3.12

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
       # 2) Встановлюємо Python
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
 
       # 3) Інсталяція залежностей
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
       - name: Install deps
         run: |
           python -m pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 COPY requirements.txt .


### PR DESCRIPTION
## Summary
- use Python 3.12 in Dockerfile
- run CI and CD with Python 3.12

## Testing
- `pytest -q`
- `docker build -t company-site-test .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68489a008a548322a261271ba40fcf77